### PR TITLE
feat: add CORS fallback for Google Sheets fetch

### DIFF
--- a/HK_20_vs_5Factors_Online.html
+++ b/HK_20_vs_5Factors_Online.html
@@ -155,8 +155,14 @@ async function loadFactors(url){
   const hint=document.getElementById('loadHint'); hint.style.display='inline';
   try{
     const bust=(url.includes('?')?'&':'?') + 't=' + Date.now();
-    const res=await fetch(url + bust);
-    if(!res.ok) throw new Error('HTTP '+res.status);
+    let res;
+    try{
+      res = await fetch(url + bust);
+      if(!res.ok) throw new Error('HTTP '+res.status);
+    }catch(err){
+      res = await fetch('https://cors.isomorphic-git.org/' + url + bust);
+      if(!res.ok) throw new Error('HTTP '+res.status);
+    }
     const text=await res.text();
     const parsed=parseCSV(text);
     factorsSeries=seriesFromCsv(parsed);


### PR DESCRIPTION
## Summary
- fallback to CORS proxy when direct CSV fetch fails

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d8044ca08832e89c1c1610639f81f