### PR TITLE
Load PapaParse and ECharts via CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,5 @@
+<script src="https://cdn.jsdelivr.net/npm/papaparse@5/dist/papaparse.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
 <script>
 const _ts = `?v=${Date.now()}`;
 const SOURCES = [


### PR DESCRIPTION
## Summary
- load PapaParse and ECharts from jsDelivr before existing script

## Testing
- `curl -I https://cdn.jsdelivr.net/npm/papaparse@5/dist/papaparse.min.js` *(fails: CONNECT tunnel failed, response 403)*
- `curl -I https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js` *(fails: CONNECT tunnel failed, response 403)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e198fc678832eac5d54a7d2f0df51