### PR TITLE
Fix scatter dot color retrieval

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,7 +321,7 @@ function buildSeries(rows, opt){
     series.push({
       type:'scatter', name:'Amber',
       data: amber, symbolSize:6,
-      itemStyle:{color:getComputedStyle(document.documentElement).getPropertyValue('--amber')},
+      itemStyle:{color:getComputedStyle(document.documentElement).getPropertyValue('--amber').trim()},
       z:4
     });
   }
@@ -329,7 +329,7 @@ function buildSeries(rows, opt){
     series.push({
       type:'scatter', name:'Red',
       data: red, symbolSize:6,
-      itemStyle:{color:getComputedStyle(document.documentElement).getPropertyValue('--red')},
+      itemStyle:{color:getComputedStyle(document.documentElement).getPropertyValue('--red').trim()},
       z:4
     });
   }


### PR DESCRIPTION
## Summary
- Trim whitespace from CSS variable values when setting scatter plot dot colors

## Testing
- `node - <<'NODE'
const fs=require('fs');
const html=fs.readFileSync('index.html','utf8');
const amberColor=html.match(/--amber:([^;]+);/)[1];
const redColor=html.match(/--red:([^;]+);/)[1];
console.log('Amber color', amberColor.trim());
console.log('Red color', redColor.trim());

const rs=[0.05,-0.02,0,0.1,-0.03];
const amber=[], red=[];
for(const v of rs){
 if(v>=0) amber.push(v+0.03);
 else red.push(v-0.03);
}
console.log('Amber values', amber);
console.log('Red values', red);
NODE`
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f22f47338832ea1aa6f9c87626904